### PR TITLE
ATG: Fix Ui Input Dialog sharing states with each other 

### DIFF
--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/HackingScreen.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/HackingScreen.kt
@@ -15,7 +15,7 @@ import com.kuhakupixel.atg.ui.menu.AddressTableMenu
 import com.kuhakupixel.atg.ui.menu.MemoryMenu
 import com.kuhakupixel.atg.ui.menu.ProcessMenu
 import com.kuhakupixel.atg.ui.menu.SettingsMenu
-import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayManager
+import com.kuhakupixel.atg.ui.overlay.OverlayManager
 
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/MainActivity.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.kuhakupixel.atg.ui.overlay.OverlayPermission
 import com.kuhakupixel.atg.ui.theme.AtgTheme
 import com.topjohnwu.superuser.Shell
 
@@ -22,14 +23,6 @@ class MainActivity : ComponentActivity() {
     /**
      * returns true if permission is given, false otherwise
      * */
-    fun askForOverlayPermission() {
-        // if not construct intent to request permi
-        val intent = Intent(
-            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-            Uri.parse("package:" + applicationContext.packageName)
-        )
-        startActivityForResult(intent, 0)
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,8 +39,15 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background
                     ) {
-                        //HackingScreen()
-                        MainScreen(askForOverlayPermission = { askForOverlayPermission() })
+                        MainScreen(
+                            askForOverlayPermission = {
+
+                                OverlayPermission.askForOverlayPermission(
+                                    context = applicationContext,
+                                    componentActivity = this,
+                                )
+                            },
+                        )
                     }
                 }
             }

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/AddressTableMenu.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/AddressTableMenu.kt
@@ -44,13 +44,13 @@ fun AddressTableMenu(globalConf: GlobalConf?, overlayManager: OverlayManager?) {
             savedAddressList = savedAddresList,
             ace = ace,
             onAddressClicked = { numType: NumType, address: String ->
-                overlayManager!!.InputDialog(
+                overlayManager!!.getInputDialog().show(
                     title = "Edit value of $address",
                     onConfirm = { input: String ->
                         try {
                             ace.WriteValueAtAddress(numType, address, input)
                         } catch (e: ACEBaseClient.InvalidCommandException) {
-                            overlayManager!!.Dialog(
+                            overlayManager!!.getInfoDialog().show(
                                 title = "Error",
                                 text = e.stackTraceToString(),
                                 onConfirm = {},

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/AddressTableMenu.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/AddressTableMenu.kt
@@ -15,7 +15,7 @@ import com.kuhakupixel.atg.backend.ACE.MatchInfo
 import com.kuhakupixel.atg.backend.ACE.NumType
 import com.kuhakupixel.atg.backend.ACEBaseClient
 import com.kuhakupixel.atg.ui.GlobalConf
-import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayManager
+import com.kuhakupixel.atg.ui.overlay.OverlayManager
 import com.kuhakupixel.atg.ui.util.CreateTable
 
 class AddressInfo(val matchInfo: MatchInfo, val numType: NumType) {

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Home.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Home.kt
@@ -2,6 +2,7 @@ package com.kuhakupixel.atg.ui.menu
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.provider.Settings
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Memory.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Memory.kt
@@ -337,7 +337,7 @@ private fun MatchesSetting(
             options = scanTypeList,
             selectedOptionIndex = selectedOptionIndex.value,
             onShowOptions = fun(options: List<String>) {
-                overlayManager.overlayScanTypeDialog.show(
+                overlayManager.getChoicesDialog().show(
                     title = "Value: ",
                     choices = options,
                     onConfirm = { index: Int, value: String ->
@@ -370,7 +370,7 @@ private fun MatchesSetting(
             options = valueTypeList,
             selectedOptionIndex = selectedOptionIndex.value,
             onShowOptions = fun(options: List<String>) {
-                overlayManager.overlayValueTypeDialog.show(
+                overlayManager.getChoicesDialog().show(
                     title = "Value: ",
                     choices = options,
                     onConfirm = { index: Int, value: String ->

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Memory.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Memory.kt
@@ -32,8 +32,7 @@ import com.kuhakupixel.atg.backend.ACE.Operator
 import com.kuhakupixel.atg.backend.ACE.operatorEnumToSymbolBiMap
 import com.kuhakupixel.atg.backend.ACEBaseClient.InvalidCommandException
 import com.kuhakupixel.atg.ui.GlobalConf
-import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayManager
-import com.kuhakupixel.atg.ui.util.CheckboxWithText
+import com.kuhakupixel.atg.ui.overlay.OverlayManager
 import com.kuhakupixel.atg.ui.util.CreateTable
 import com.kuhakupixel.atg.ui.util.NumberInputField
 import com.kuhakupixel.atg.ui.util.OverlayDropDown

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Memory.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Memory.kt
@@ -170,7 +170,7 @@ fun _MemoryMenu(
                             )
                         }
                     } catch (e: InvalidCommandException) {
-                        overlayManager!!.Dialog(
+                        overlayManager!!.getInfoDialog().show(
                             title = "Error",
                             text = e.stackTraceToString(),
                             onConfirm = {},

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Process.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Process.kt
@@ -214,13 +214,13 @@ fun ProcessMenu(globalConf: GlobalConf?, overlayManager: OverlayManager?) {
     _ProcessMenu(
         currentProcList,
         onAttach = { pid: Long, procName: String ->
-            overlayManager!!.Dialog(
+            overlayManager!!.getInfoDialog().show(
                 title = "Attach to ${pid} - ${procName} ? ", text = "",
                 onConfirm = {
                     AttachToProcess(
                         ace = ace, pid = pid,
                         onAttachSuccess = {
-                            overlayManager.Dialog(
+                            overlayManager!!.getInfoDialog().show(
                                 title = "Attaching to ${procName} is successful",
                                 onConfirm = {},
                                 text = "",
@@ -228,14 +228,14 @@ fun ProcessMenu(globalConf: GlobalConf?, overlayManager: OverlayManager?) {
                             attachedStatusString.value = "${pid} - ${procName}"
                         },
                         onProcessNoExistAnymore = {
-                            overlayManager.Dialog(
+                            overlayManager!!.getInfoDialog().show(
                                 title = "Process ${procName} is not running anymore, Can't attach",
                                 onConfirm = {},
                                 text = "",
                             )
                         },
                         onAttachFailure = { msg: String ->
-                            overlayManager.Dialog(
+                            overlayManager!!.getInfoDialog().show(
                                 title = msg,
                                 onConfirm = {},
                                 text = "",
@@ -248,7 +248,7 @@ fun ProcessMenu(globalConf: GlobalConf?, overlayManager: OverlayManager?) {
         onRefreshClicked = { refreshProcList(ace, currentProcList) },
         onConnectToACEServerClicked = {
 
-            overlayManager!!.InputDialog(
+            overlayManager!!.getInputDialog().show(
                 "Port: ",
                 onConfirm = { input: String ->
                     val port = input.toInt()

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Process.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/menu/Process.kt
@@ -25,7 +25,7 @@ import com.kuhakupixel.atg.R
 import com.kuhakupixel.atg.backend.ACE
 import com.kuhakupixel.atg.backend.ProcInfo
 import com.kuhakupixel.atg.ui.GlobalConf
-import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayManager
+import com.kuhakupixel.atg.ui.overlay.OverlayManager
 import com.kuhakupixel.atg.ui.util.CreateTable
 
 /**

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayManager.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayManager.kt
@@ -17,7 +17,7 @@ class OverlayManager(
         content: @Composable () -> Unit,
     ): OverlayViewHolder {
 
-        val hackingScreen = OverlayViewHolder(
+        val dialogViewHolder = OverlayViewHolder(
             windowManager = windowManager,
             params = WindowManager.LayoutParams(
                 WindowManager.LayoutParams.MATCH_PARENT,
@@ -32,26 +32,16 @@ class OverlayManager(
             service = service,
         )
 
-        hackingScreen.setContent {
+        dialogViewHolder.setContent {
             content()
         }
 
-        return hackingScreen
+        return dialogViewHolder
     }
-
-    // TODO: Fix This, Because its duplicate and ugly :(
-    val overlayScanTypeDialog = OverlayChoicesDialog(
-        createDialogOverlay = ::createDialogOverlay,
-        windowManager = windowManager
-    )
-
-    val overlayValueTypeDialog = OverlayChoicesDialog(
-        createDialogOverlay = ::createDialogOverlay,
-        windowManager = windowManager
-    )
 
     init {
     }
+
     fun getInfoDialog(): OverlayInfoDialog {
         return OverlayInfoDialog(
             createDialogOverlay = ::createDialogOverlay,
@@ -61,6 +51,13 @@ class OverlayManager(
 
     fun getInputDialog(): OverlayInputDialog {
         return OverlayInputDialog(
+            createDialogOverlay = ::createDialogOverlay,
+            windowManager = windowManager
+        )
+    }
+
+    fun getChoicesDialog(): OverlayChoicesDialog {
+        return OverlayChoicesDialog(
             createDialogOverlay = ::createDialogOverlay,
             windowManager = windowManager
         )

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayManager.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayManager.kt
@@ -1,10 +1,12 @@
-package com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI
+package com.kuhakupixel.atg.ui.overlay
 
 import android.graphics.PixelFormat
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
-import com.kuhakupixel.atg.ui.overlay.OverlayViewHolder
 import com.kuhakupixel.atg.ui.overlay.service.FloatingService
+import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayChoicesDialog
+import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayInfoDialog
+import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayInputDialog
 
 class OverlayManager(
     private val windowManager: WindowManager,

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayPermission.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayPermission.kt
@@ -1,0 +1,22 @@
+package com.kuhakupixel.atg.ui.overlay
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+
+class OverlayPermission {
+
+    companion object {
+        fun askForOverlayPermission(context: Context, componentActivity: ComponentActivity) {
+            // if not construct intent to request permi
+            // https://stackoverflow.com/a/40583163/14073678
+            val intent = Intent(
+                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                Uri.parse("package:" + context.packageName)
+            )
+            componentActivity.startActivityForResult(intent, 0)
+        }
+    }
+}

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayViewHolder.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayViewHolder.kt
@@ -1,6 +1,5 @@
 package com.kuhakupixel.atg.ui.overlay
 
-import android.content.pm.ActivityInfo
 import android.view.Gravity
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
@@ -44,21 +43,19 @@ class OverlayViewHolder(
         windowManager.updateViewLayout(view, params)
     }
 
-    fun disable() {
-        // set not visible
-        params.alpha = 0f
-        // not touchable so it won't block input when disabled
-        params.flags =
-            WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-        windowManager.updateViewLayout(view, params)
-    }
-
-    fun enable() {
-        params.alpha = originalWindowAlpha
-        // not touchable so it won't block input when disabled
-        params.flags = originalWindowFlag
-        // lock if potrait only
-        windowManager.updateViewLayout(view, params)
+    fun setVisible(visible: Boolean) {
+        if (visible) {
+            params.alpha = originalWindowAlpha
+            // not touchable so it won't block input when disabled
+            params.flags = originalWindowFlag
+            windowManager.updateViewLayout(view, params)
+        } else {
+            params.alpha = 0f
+            // not touchable so it won't block input when disabled
+            params.flags =
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+            windowManager.updateViewLayout(view, params)
+        }
     }
 
     fun setContent(content: @Composable (composeView: ComposeView) -> Unit = {}) {

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayViewHolder.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayViewHolder.kt
@@ -20,16 +20,13 @@ class OverlayViewHolder(
 
     val originalWindowFlag: Int
     val originalWindowAlpha: Float
-    val originalScreenOrientation: Int
 
     init {
         params.gravity = Gravity.TOP or Gravity.LEFT
         params.alpha = alpha
-        //
         // save original params
         originalWindowFlag = params.flags
         originalWindowAlpha = params.alpha
-        originalScreenOrientation = params.screenOrientation
     }
 
     fun getParams(): WindowManager.LayoutParams {
@@ -48,8 +45,6 @@ class OverlayViewHolder(
     }
 
     fun disable() {
-        // make sure so screen is not locked up to one orientation
-        params.screenOrientation = originalScreenOrientation
         // set not visible
         params.alpha = 0f
         // not touchable so it won't block input when disabled

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayViewHolder.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/OverlayViewHolder.kt
@@ -14,7 +14,6 @@ class OverlayViewHolder(
     private val params: WindowManager.LayoutParams,
     val alpha: Float,
     val service: FloatingService,
-    val potraitOnly: Boolean = false,
 ) {
 
     private var view: ComposeView? = null
@@ -64,8 +63,6 @@ class OverlayViewHolder(
         // not touchable so it won't block input when disabled
         params.flags = originalWindowFlag
         // lock if potrait only
-        if (potraitOnly)
-            params.screenOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         windowManager.updateViewLayout(view, params)
     }
 

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayDialog.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kuhakupixel.atg.ui.overlay.OverlayViewHolder
+import com.kuhakupixel.atg.ui.overlay.service.OverlayEnableDisableMode
 import com.kuhakupixel.atg.ui.overlay.service.OverlayViewController
 import com.kuhakupixel.atg.ui.theme.AtgTheme
 
@@ -122,7 +123,7 @@ open class OverlayDialog(
                     }
                 },
                 windowManager = windowManager,
-                disableByDestroy = true,
+                enableDisableMode = OverlayEnableDisableMode.CREATE_AND_DESTROY,
             )
     }
 

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayDialog.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayDialog.kt
@@ -122,6 +122,7 @@ open class OverlayDialog(
                     }
                 },
                 windowManager = windowManager,
+                disableByDestroy = true,
             )
     }
 

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayManager.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayManager.kt
@@ -69,4 +69,11 @@ class OverlayManager(
     fun InputDialog(title: String, onConfirm: (input: String) -> Unit) {
         overlayInputDialog.show(title = title, onConfirm = onConfirm)
     }
+
+    fun getInfoDialog(): OverlayInfoDialog {
+        return OverlayInfoDialog(
+            createDialogOverlay = ::createDialogOverlay,
+            windowManager = windowManager
+        )
+    }
 }

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayManager.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayComposeUI/OverlayManager.kt
@@ -37,16 +37,6 @@ class OverlayManager(
         return hackingScreen
     }
 
-    private var overlayInputDialog = OverlayInputDialog(
-        createDialogOverlay = ::createDialogOverlay,
-        windowManager = windowManager
-    )
-
-    private var overlayInfoDialog = OverlayInfoDialog(
-        createDialogOverlay = ::createDialogOverlay,
-        windowManager = windowManager
-    )
-
     // TODO: Fix This, Because its duplicate and ugly :(
     val overlayScanTypeDialog = OverlayChoicesDialog(
         createDialogOverlay = ::createDialogOverlay,
@@ -60,18 +50,15 @@ class OverlayManager(
 
     init {
     }
-
-    fun Dialog(title: String, text: String, onConfirm: () -> Unit) {
-        overlayInfoDialog.show(title = title, text = text, onConfirm = onConfirm)
-
-    }
-
-    fun InputDialog(title: String, onConfirm: (input: String) -> Unit) {
-        overlayInputDialog.show(title = title, onConfirm = onConfirm)
-    }
-
     fun getInfoDialog(): OverlayInfoDialog {
         return OverlayInfoDialog(
+            createDialogOverlay = ::createDialogOverlay,
+            windowManager = windowManager
+        )
+    }
+
+    fun getInputDialog(): OverlayInputDialog {
+        return OverlayInputDialog(
             createDialogOverlay = ::createDialogOverlay,
             windowManager = windowManager
         )

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
@@ -63,21 +63,22 @@ class OverlayHackingScreenController(
                                 Text("Close")
                             }
 
+                            /*
                             Button(
 
                                 onClick = {
-                                    val infoDialog: OverlayInfoDialog =
-                                        overlayManager.getInfoDialog()
-                                    infoDialog.show(
+                                    overlayManager.getInputDialog().show(
                                         "Hello",
-                                        text = "Test",
-                                        onConfirm = {}
+                                        onConfirm = { input: String ->
+
+                                        }
                                     )
                                 }
 
                             ) {
                                 Text("Dialog Test")
                             }
+                             */
                         }
                         HackingScreen(overlayManager = overlayManager)
                     }

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
@@ -29,10 +29,6 @@ class OverlayHackingScreenController(
         name = "Hacking Screen",
     )
 
-    var currentCounter = 0
-    val dropdownEnabled: MutableState<Boolean> = mutableStateOf(true)
-    val dropdownExpanded: MutableState<Boolean> = mutableStateOf(false)
-    val dropdownSelectedIdx: MutableState<Int> = mutableStateOf(0)
     private fun createOverlay(): OverlayViewHolder {
 
         val hackingScreen = OverlayViewHolder(
@@ -48,7 +44,6 @@ class OverlayHackingScreenController(
             ),
             alpha = 0.9f,
             service = service,
-            potraitOnly = false,
         )
 
         hackingScreen.setContent {

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import com.kuhakupixel.atg.ui.HackingScreen
 import com.kuhakupixel.atg.ui.overlay.OverlayViewHolder
+import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayInfoDialog
 import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayManager
 import com.kuhakupixel.atg.ui.theme.AtgTheme
 
@@ -62,6 +63,22 @@ class OverlayHackingScreenController(
                         ) {
                             Button(onClick = onClosed) {
                                 Text("Close")
+                            }
+
+                            Button(
+
+                                onClick = {
+                                    val infoDialog: OverlayInfoDialog =
+                                        overlayManager.getInfoDialog()
+                                    infoDialog.show(
+                                        "Hello",
+                                        text = "Test",
+                                        onConfirm = {}
+                                    )
+                                }
+
+                            ) {
+                                Text("Dialog Test")
                             }
                         }
                         HackingScreen(overlayManager = overlayManager)

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayHackingScreenController.kt
@@ -11,13 +11,11 @@ import androidx.compose.material.Text
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import com.kuhakupixel.atg.ui.HackingScreen
 import com.kuhakupixel.atg.ui.overlay.OverlayViewHolder
 import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayInfoDialog
-import com.kuhakupixel.atg.ui.overlay.service.OverlayComposeUI.OverlayManager
+import com.kuhakupixel.atg.ui.overlay.OverlayManager
 import com.kuhakupixel.atg.ui.theme.AtgTheme
 
 class OverlayHackingScreenController(

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayViewController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayViewController.kt
@@ -74,8 +74,12 @@ class OverlayViewController(
                  * cannot explain why this happened but it happened, so I need it to be this way
                  * to prevent that
                  * */
-                if (enabledCount >= 1)
-                    throw IllegalStateException("Cannot reuse this view controller because it is not thread safe , a new instance is needed ")
+                if (enabledCount >= 1) {
+                    throw IllegalStateException(
+                        "Cannot reuse this view controller when [enableDisableMode] is set to [${this.enableDisableMode.toString()}] " +
+                                "because it is not thread safe when creating/destroying, a new instance is needed "
+                    )
+                }
                 //
                 viewHolder = createOverlayViewHolder()
                 logd("${name}: adding view ${viewHolder!!.getView()}")

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayViewController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayViewController.kt
@@ -1,33 +1,51 @@
 package com.kuhakupixel.atg.ui.overlay.service
 
+import android.util.Log
+import android.view.ViewGroup
 import android.view.WindowManager
 import com.kuhakupixel.atg.ui.overlay.OverlayViewHolder
 import com.kuhakupixel.atg.ui.overlay.logd
 
+/**
+ * when [disableByDestroy] is set to false, it will disable the view
+ * only by setting it's alpha to 0, this has advantage
+ * where it will be faster to load
+ * */
 class OverlayViewController(
     val createOverlayViewHolder: () -> OverlayViewHolder,
     val windowManager: WindowManager,
     val name: String = "",
+    val disableByDestroy: Boolean = false,
 ) : OverlayInterface {
     private var viewHolder: OverlayViewHolder? = null
 
     init {
-        viewHolder = createOverlayViewHolder()
-        logd("${name}: adding view ${viewHolder!!.getView()}")
-        windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
-        viewHolder!!.disable()
+        if (!disableByDestroy) {
+            viewHolder = createOverlayViewHolder()
+            logd("${name}: adding view ${viewHolder!!.getView()}")
+            windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
+            viewHolder!!.setVisible(false)
+        }
     }
 
     override fun enableView() {
-        viewHolder!!.enable()
+        if (!disableByDestroy) {
+            viewHolder!!.setVisible(true)
+        } else {
+            viewHolder = createOverlayViewHolder()
+            logd("${name}: adding view ${viewHolder!!.getView()}")
+            windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
+            Log.d("ATG", "View Spawned")
+        }
     }
 
     override fun disableView() {
-        viewHolder!!.disable()
-        /*
-        logd("${name}: removing view ${viewHolder!!.getView()}")
-        windowManager.removeView(viewHolder!!.getView())
-         */
+        if (!disableByDestroy) {
+            viewHolder!!.setVisible(false)
+        } else {
+            windowManager.removeView(viewHolder!!.getView())
+            Log.d("ATG", "View Destroyed")
+        }
     }
 
 }

--- a/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayViewController.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/ui/overlay/service/OverlayViewController.kt
@@ -1,13 +1,32 @@
 package com.kuhakupixel.atg.ui.overlay.service
 
 import android.util.Log
-import android.view.ViewGroup
 import android.view.WindowManager
 import com.kuhakupixel.atg.ui.overlay.OverlayViewHolder
 import com.kuhakupixel.atg.ui.overlay.logd
 
+enum class OverlayEnableDisableMode {
+    /**
+     * Create new view when enabled and
+     * destroy view when disabled
+     *
+     * preferable if the overlay view is intended to be used only once
+     * where we don't want to remember its state anymore
+     * */
+    CREATE_AND_DESTROY,
+
+    /**
+     * Set view to visible when enabled
+     * and set view to invisible when disabled
+     *
+     * preferable if we want to remember the overlay view 's state
+     * after we disable and enable it
+     * */
+    VISIBLE_AND_INVISIBLE,
+}
+
 /**
- * when [disableByDestroy] is set to false, it will disable the view
+ * when [enableDisableMode] is set to false, it will disable the view
  * only by setting it's alpha to 0, this has advantage
  * where it will be faster to load
  * */
@@ -15,56 +34,69 @@ class OverlayViewController(
     val createOverlayViewHolder: () -> OverlayViewHolder,
     val windowManager: WindowManager,
     val name: String = "",
-    val disableByDestroy: Boolean = false,
+    val enableDisableMode: OverlayEnableDisableMode = OverlayEnableDisableMode.VISIBLE_AND_INVISIBLE,
 ) : OverlayInterface {
     private var viewHolder: OverlayViewHolder? = null
     private var enabledCount = 0
 
     init {
-        if (!disableByDestroy) {
-            viewHolder = createOverlayViewHolder()
-            logd("${name}: adding view ${viewHolder!!.getView()}")
-            windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
-            viewHolder!!.setVisible(false)
+        when (enableDisableMode) {
+            OverlayEnableDisableMode.VISIBLE_AND_INVISIBLE -> {
+                viewHolder = createOverlayViewHolder()
+                logd("${name}: adding view ${viewHolder!!.getView()}")
+                windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
+                viewHolder!!.setVisible(false)
+            }
+
+            OverlayEnableDisableMode.CREATE_AND_DESTROY -> {}
         }
     }
 
     override fun enableView() {
-        if (!disableByDestroy) {
-            viewHolder!!.setVisible(true)
-        } else {
-            /**
-             * prevent reuse  (enable, disable  and then enable again)
-             * in the same instance because the code is not thread safe
-             *
-             * so instead to reuse, a new instance is needed everytime
-             *
-             * (I find the bug, where I have a button that shows a dialog (with close button
-             * that destroy the dialog it self) and find that if I happens to click the show
-             * dialog button twice, before the dialog even show, then there can be a bug
-             * where the dialog created isn't attached to WindowManager for some reason
-             * therefore when trying to destroy it, it will cause crash (not attached to windowmanager exception)
-             *
-             * cannot explain why this happened but it happened, so I need it to be this way
-             * to prevent that
-             * */
-            if (enabledCount >= 1)
-                throw IllegalStateException("Cannot reuse this view controller because it is not thread safe , a new instance is needed ")
-            //
-            viewHolder = createOverlayViewHolder()
-            logd("${name}: adding view ${viewHolder!!.getView()}")
-            windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
-            Log.d("ATG", "View Spawned")
+        when (enableDisableMode) {
+            OverlayEnableDisableMode.VISIBLE_AND_INVISIBLE -> {
+                viewHolder!!.setVisible(true)
+            }
+
+            OverlayEnableDisableMode.CREATE_AND_DESTROY -> {
+                /**
+                 * prevent reuse  (enable, disable  and then enable again)
+                 * in the same instance because the code is not thread safe
+                 *
+                 * so instead to reuse, a new instance is needed everytime
+                 *
+                 * (I find the bug, where I have a button that shows a dialog (with close button
+                 * that destroy the dialog it self) and find that if I happens to click the show
+                 * dialog button twice, before the dialog even show, then there can be a bug
+                 * where the dialog created isn't attached to WindowManager for some reason
+                 * therefore when trying to destroy it, it will cause crash (not attached to windowmanager exception)
+                 *
+                 * cannot explain why this happened but it happened, so I need it to be this way
+                 * to prevent that
+                 * */
+                if (enabledCount >= 1)
+                    throw IllegalStateException("Cannot reuse this view controller because it is not thread safe , a new instance is needed ")
+                //
+                viewHolder = createOverlayViewHolder()
+                logd("${name}: adding view ${viewHolder!!.getView()}")
+                windowManager.addView(viewHolder!!.getView(), viewHolder!!.getParams())
+                Log.d("ATG", "View Spawned")
+            }
         }
         enabledCount++
     }
 
     override fun disableView() {
-        if (!disableByDestroy) {
-            viewHolder!!.setVisible(false)
-        } else {
-            windowManager.removeView(viewHolder!!.getView())
-            Log.d("ATG", "View Destroyed")
+
+        when (enableDisableMode) {
+            OverlayEnableDisableMode.VISIBLE_AND_INVISIBLE -> {
+                viewHolder!!.setVisible(false)
+            }
+
+            OverlayEnableDisableMode.CREATE_AND_DESTROY -> {
+                windowManager.removeView(viewHolder!!.getView())
+                Log.d("ATG", "View Destroyed")
+            }
         }
     }
 


### PR DESCRIPTION
Opening multiple input dialog will share the same input between each other, instead of being empty from start