### PR TITLE
Modder: fix build error when adding smali code to a dex file that is already at its limit

### DIFF
--- a/Modder/injector/gen_smali.py
+++ b/Modder/injector/gen_smali.py
@@ -92,7 +92,7 @@ with tempfile.TemporaryDirectory() as TEMP_DECOMPILED_APK_DIR:
     # it will do it for us
     OUT_SMALI_DIR_ZIPPED_FILE = OUT_SMALI_DIR 
     shutil.make_archive(
-        base_name=OUT_SMALI_DIR_ZIPPED_FILE, format="zip", base_dir=GENERATED_SMALI_DIR
+        OUT_SMALI_DIR_ZIPPED_FILE, "zip", GENERATED_SMALI_DIR
     )
     print("Generated zipped smali at %s" % (OUT_SMALI_DIR_ZIPPED_FILE))
     print("Code for injection is generated at %s" % (OUT_CODE_FOR_INJECT_DIR))

--- a/Modder/modder/build.gradle
+++ b/Modder/modder/build.gradle
@@ -25,13 +25,8 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
 
     //
-    // implementation 'org.apktool:apktool-lib:2.6.1'
     implementation 'net.lingala.zip4j:zip4j:2.11.3'
     // auto signer
-    // TODO: add docker file for uber signer project
-    // for easier build in the future, because I can't build them
-    // probably  some missmatch of java version
-    // Add file dependacy
     // https://stackoverflow.com/a/20956456/14073678
     implementation files("./lib/uber-apk-signer-1.3.0.jar")
     implementation files("./lib/apktool-cli-all_2.8.1.jar")
@@ -46,6 +41,9 @@ dependencies {
 
     // cli
     implementation 'info.picocli:picocli:4.7.5'
+    // logging
+    implementation 'ch.qos.logback:logback-classic:1.4.11'
+    implementation 'io.github.oshai:kotlin-logging-jvm:5.0.0'
 
 
 }

--- a/Modder/modder/src/main/java/modder/Log.kt
+++ b/Modder/modder/src/main/java/modder/Log.kt
@@ -1,0 +1,5 @@
+package modder
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+val logger = KotlinLogging.logger{}

--- a/Modder/modder/src/main/java/modder/Main.kt
+++ b/Modder/modder/src/main/java/modder/Main.kt
@@ -31,9 +31,9 @@ class Main {
         fun main(args: Array<String>) {
             // Some testing
             if (Util.DoesCommandExist("adb")) {
-                println("adb exist")
+                logger.info { "adb exist" }
             } else {
-                println("adb doesn't exist")
+                logger.error{"adb doesn't exist"}
             }
             cliInit(args)
         }

--- a/Modder/modder/src/main/java/modder/ModderMainCmd.kt
+++ b/Modder/modder/src/main/java/modder/ModderMainCmd.kt
@@ -94,7 +94,11 @@ class ModderMainCmd {
     @CommandLine.Command(name = "Patch", description = ["recompile apks"])
 
     fun Patch(
-            @CommandLine.Parameters(paramLabel = "ApkFolderPath", description = ["Path to directory containing apks"]) apkDirStr: String
+            @CommandLine.Parameters(paramLabel = "ApkFolderPath", description = ["Path to directory containing apks"])
+            apkDirStr: String,
+
+            @CommandLine.Parameters(paramLabel = "cleanDecompiledOnExit",description = ["clean decompiled apk folder when program exits, default:\${DEFAULT-VALUE} "], defaultValue = "true")
+            cleanDecompiledOnExit: Boolean
     ) {
 
         // check if the directory exist
@@ -123,6 +127,7 @@ class ModderMainCmd {
                 // when extractNativeLibsOption == false
                 // otherwise don't decode to make compilation recompilation faster
                 decodeResource = (extractNativeLibsOption == false),
+                cleanDecompilationOnExit = cleanDecompiledOnExit,
         )
         if (extractNativeLibsOption == false) {
             println("extractNativeLibsOptions is set to false, attempting to remove them")

--- a/Modder/modder/src/main/java/modder/Patcher.kt
+++ b/Modder/modder/src/main/java/modder/Patcher.kt
@@ -13,7 +13,7 @@ import java.nio.file.Paths
 // called MemScanner 
 class Patcher(
         apkFilePathStr: String,
-        tempFolderTaskOnExit: TempManager.TaskOnExit = TempManager.TaskOnExit.clean,
+        cleanDecompilationOnExit: Boolean = true,
         val decodeResource: Boolean,
 ) {
     var apkFilePathStr: String
@@ -26,12 +26,12 @@ class Patcher(
         Assert.AssertExistAndIsFile(apkFile)
         // make sure to get the absolute path
         this.apkFilePathStr = apkFile.absolutePath
-        val tempDir = TempManager.CreateTempDirectory("ModderDecompiledApk", tempFolderTaskOnExit)
+        val tempDir = TempManager.CreateTempDirectory("ModderDecompiledApk", cleanDecompilationOnExit)
         // make sure we have the absolute path
         // https://stackoverflow.com/a/17552395/14073678
         decompiledApkDirStr = tempDir.toAbsolutePath().toString()
         // =============================== decompile the apk ===========
-        logger.info{"decompiled at ${decompiledApkDirStr}"}
+        logger.info { "decompiled at ${decompiledApkDirStr}" }
         ApkToolWrap.Decompile(apkFilePathStr, decompiledApkDirStr, decodeResource = this.decodeResource)
     }
 
@@ -232,22 +232,25 @@ class Patcher(
 
 
     fun AddMemScannerSmaliCode() {
-        // path to copy the smali constructor to
-        val smaliCodePackageDir = GetPackageDirOfLaunchableActivity()
 
-        // copy the zip code of smali constructor from resources
-        // unextract it in a temp folder and then copy to
-        // the apk
+        /**
+         * copy the zip code of smali constructor from resources
+         * to a temp folder and then extract to the apk
+         */
+
+        // copy zip to temp folder
         val tempDir: String = TempManager.CreateTempDirectory("TempSmalifolder").toString()
-        //
         val destSmaliZipCode = File(tempDir, MEM_SCANNER_SMALI_ZIP_NAME)
         resource.CopyResourceFile(MEM_SCANNER_SMALI_CODE_ZIP_PATH, destSmaliZipCode.absolutePath)
+        // path to copy the smali code to
+        val smaliCodePackageDir = GetPackageDirOfLaunchableActivity()
+        //
         val destDir = File(smaliCodePackageDir, MEM_SCANNER_SMALI_DIR_NAME).absolutePath
-        val zipFile = ZipFile(destSmaliZipCode.absolutePath)
-        zipFile.extractAll(destDir)
-        System.out.printf("extracted to %s\n", destDir)
-        zipFile.close()
-        System.out.printf("copying resource to %s\n", destDir)
+        ZipFile(destSmaliZipCode.absolutePath).use { zipFile: ZipFile ->
+            zipFile.extractAll(destDir)
+            zipFile.close()
+        }
+        logger.info { "extracted to ${destDir}" }
     }
 
 
@@ -259,12 +262,11 @@ class Patcher(
         // server to the init function of smali launchable file
         val entrySmaliPathStr = GetEntrySmaliPath()
         val entrySmaliPath = Paths.get(entrySmaliPathStr)
-        println("using log4j")
         logger.info { "entry smali file: ${entrySmaliPathStr}" }
         val modifiedSmaliCode = AddMemScannerConstructorSmaliCode(entrySmaliPathStr)
-        logger.info { "========== modified smali code ========================" }
-        logger.info { modifiedSmaliCode.joinToString(separator = "\n") }
-        logger.info { "==================================================" }
+        //logger.info { "========== modified smali code ========================" }
+        //logger.info { modifiedSmaliCode.joinToString(separator = "\n") }
+        //logger.info { "==================================================" }
         // rewrite file
         Files.write(entrySmaliPath, modifiedSmaliCode)
     }
@@ -321,10 +323,11 @@ class Patcher(
 
         // smali code
         const val MEM_SCANNER_SMALI_DIR_NAME = "AceInjector"
+        // code to inject's path from resource
         val MEM_SCANNER_SMALI_BASE_DIR = "/" + java.lang.String.join("/", "AceAndroidLib", "code_to_inject", "smali", "com")
         const val MEM_SCANNER_SMALI_ZIP_NAME = MEM_SCANNER_SMALI_DIR_NAME + ".zip"
-        val MEM_SCANNER_SMALI_RESOURCE_DIR = File(MEM_SCANNER_SMALI_BASE_DIR, MEM_SCANNER_SMALI_ZIP_NAME).absolutePath
         val MEM_SCANNER_SMALI_CODE_ZIP_PATH = java.lang.String.join("/", MEM_SCANNER_SMALI_BASE_DIR, MEM_SCANNER_SMALI_ZIP_NAME)
+        // smali code to start the service
         const val MEM_SCANNER_CONSTRUCTOR_SMALI_CODE = "invoke-static {}, Lcom/AceInjector/utils/Injector;->Init()V"
 
         fun LaunchableActivityToSmaliRelativePath(launchableActivity: String): String {

--- a/Modder/modder/src/main/java/modder/Patcher.kt
+++ b/Modder/modder/src/main/java/modder/Patcher.kt
@@ -230,6 +230,17 @@ class Patcher(
         return smaliCodePackageDir.absolutePath
     }
 
+    fun GetSmaliClassesCount(): Int {
+
+        var count:Int =0
+        val files = File(decompiledApkDirStr).listFiles()!!
+        for (i in files.indices) {
+            if (files[i].name.startsWith("smali") && files[i].isDirectory)
+                count++
+        }
+        return count
+
+    }
 
     fun AddMemScannerSmaliCode() {
 
@@ -323,10 +334,12 @@ class Patcher(
 
         // smali code
         const val MEM_SCANNER_SMALI_DIR_NAME = "AceInjector"
+
         // code to inject's path from resource
         val MEM_SCANNER_SMALI_BASE_DIR = "/" + java.lang.String.join("/", "AceAndroidLib", "code_to_inject", "smali", "com")
         const val MEM_SCANNER_SMALI_ZIP_NAME = MEM_SCANNER_SMALI_DIR_NAME + ".zip"
         val MEM_SCANNER_SMALI_CODE_ZIP_PATH = java.lang.String.join("/", MEM_SCANNER_SMALI_BASE_DIR, MEM_SCANNER_SMALI_ZIP_NAME)
+
         // smali code to start the service
         const val MEM_SCANNER_CONSTRUCTOR_SMALI_CODE = "invoke-static {}, Lcom/AceInjector/utils/Injector;->Init()V"
 

--- a/Modder/modder/src/main/java/modder/Patcher.kt
+++ b/Modder/modder/src/main/java/modder/Patcher.kt
@@ -236,8 +236,13 @@ class Patcher(
         var count: Int = 0
         val files = File(decompiledApkDirStr).listFiles()!!
         for (i in files.indices) {
-            if (files[i].name.startsWith("smali") && files[i].isDirectory)
-                count++
+            // the first smali folder starts with "smali" and rest starts with  "smali_classes2"
+            // can't only check for startsWith("smali") because there are some folder like "smali_assets"
+            // that aren't part of the main dex class and will only mess up the [count]
+            if (files[i].name == "smali" || files[i].name.startsWith("smali_classes")) {
+                if (files[i].isDirectory)
+                    count++
+            }
         }
         return count
 
@@ -254,8 +259,7 @@ class Patcher(
         val tempDir: String = TempManager.CreateTempDirectory("TempSmalifolder").toString()
         val destSmaliZipCode = File(tempDir, MEM_SCANNER_SMALI_ZIP_NAME)
         resource.CopyResourceFile(MEM_SCANNER_SMALI_CODE_ZIP_PATH, destSmaliZipCode.absolutePath)
-        // path to copy the smali code to
-        val apkSmaliClassCount = GetSmaliClassesCount()
+
         /**
          * create new smali folder (new dex basically) to put our smali code
          * can't just use existing smali folder in order to mitigate dex limitation of 65536 max method
@@ -264,6 +268,7 @@ class Patcher(
          * */
         //
         //
+        val apkSmaliClassCount = GetSmaliClassesCount()
         val destRootDir = Path(decompiledApkDirStr, "smali_classes${apkSmaliClassCount + 1}", "com").toFile()
         assert(destRootDir.mkdirs() == true)
         val destDir = File(destRootDir, MEM_SCANNER_SMALI_DIR_NAME).absolutePath

--- a/Modder/modder/src/main/java/modder/Patcher.kt
+++ b/Modder/modder/src/main/java/modder/Patcher.kt
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.StringUtils
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
-import java.lang.IllegalStateException
 import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -32,6 +31,7 @@ class Patcher(
         // https://stackoverflow.com/a/17552395/14073678
         decompiledApkDirStr = tempDir.toAbsolutePath().toString()
         // =============================== decompile the apk ===========
+        logger.info{"decompiled at ${decompiledApkDirStr}"}
         ApkToolWrap.Decompile(apkFilePathStr, decompiledApkDirStr, decodeResource = this.decodeResource)
     }
 
@@ -259,7 +259,12 @@ class Patcher(
         // server to the init function of smali launchable file
         val entrySmaliPathStr = GetEntrySmaliPath()
         val entrySmaliPath = Paths.get(entrySmaliPathStr)
+        println("using log4j")
+        logger.info { "entry smali file: ${entrySmaliPathStr}" }
         val modifiedSmaliCode = AddMemScannerConstructorSmaliCode(entrySmaliPathStr)
+        logger.info { "========== modified smali code ========================" }
+        logger.info { modifiedSmaliCode.joinToString(separator = "\n") }
+        logger.info { "==================================================" }
         // rewrite file
         Files.write(entrySmaliPath, modifiedSmaliCode)
     }
@@ -349,6 +354,7 @@ class Patcher(
             val fileData = Files.readAllLines(entrySmaliPath, Charset.defaultCharset())
             val injectionLine = MemScannerFindInjectionLineNum(launchableSmaliFile)
             fileData.add(injectionLine + 1, MEM_SCANNER_CONSTRUCTOR_SMALI_CODE)
+            logger.info { "Injecting code at: ${launchableSmaliFile}:${injectionLine + 1} " }
             return fileData
         }
     }

--- a/Modder/modder/src/main/java/modder/TempManager.kt
+++ b/Modder/modder/src/main/java/modder/TempManager.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
 class TempManager {
 
     companion object {
-        fun CreateTempDirectory(prefix: String, taskOnExit: TaskOnExit = TaskOnExit.clean): Path {
+        fun CreateTempDirectory(prefix: String, cleanOnExit: Boolean = true): Path {
             val tempDir = Files.createTempDirectory(prefix)
             // make sure we have the absolute path
             // https://stackoverflow.com/a/17552395/14073678
@@ -25,7 +25,7 @@ class TempManager {
             // the only solution seems to be deleting the temp folder
             // recursively on shutdown
             // https://stackoverflow.com/questions/11165253/deleting-a-directory-on-exit-in-java
-            if (taskOnExit == TaskOnExit.clean) {
+            if (cleanOnExit) {
                 Runtime.getRuntime().addShutdownHook(
                         object : Thread() {
                             override fun run() {

--- a/Modder/modder/src/main/resources/logback.xml
+++ b/Modder/modder/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level :  %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/Modder/modder/src/test/java/modder/TestPatcher.kt
+++ b/Modder/modder/src/test/java/modder/TestPatcher.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.fail
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
+import kotlin.io.path.Path
 
 internal class TestPatcher {
     //
@@ -242,9 +243,9 @@ internal class TestPatcher {
     @Test
     @Throws(IOException::class)
     fun AddMemScannerSmaliCode() {
-        val patcher = Patcher(testApkPathStr, decodeResource = false)
-        val smaliCodePackageDir = patcher.GetPackageDirOfLaunchableActivity()
-        val memScannerSmaliCodeDir = File(smaliCodePackageDir, Patcher.MEM_SCANNER_SMALI_DIR_NAME)
+        val patcher = Patcher(testApkPathStr, decodeResource = false, cleanDecompilationOnExit = false)
+        // new smali code should be at newly created smali classes
+        val memScannerSmaliCodeDir = Path(patcher.decompiledApkDirStr, "smali_classes5", "com", Patcher.MEM_SCANNER_SMALI_DIR_NAME).toFile()
         Assertions.assertEquals(false, memScannerSmaliCodeDir.exists())
         patcher.AddMemScannerSmaliCode()
         Assertions.assertEquals(true, memScannerSmaliCodeDir.exists())

--- a/Modder/modder/src/test/java/modder/TestPatcher.kt
+++ b/Modder/modder/src/test/java/modder/TestPatcher.kt
@@ -240,6 +240,10 @@ internal class TestPatcher {
         patcher.AddMemScannerSmaliCode()
         Assertions.assertEquals(true, memScannerSmaliCodeDir.exists())
         Assertions.assertEquals(true, memScannerSmaliCodeDir.isDirectory)
+        // make sure content is valid
+        val smaliCodeRootDir = File(memScannerSmaliCodeDir.absolutePath, "utils")
+        Assertions.assertEquals(true, smaliCodeRootDir.exists())
+        Assertions.assertEquals(true, smaliCodeRootDir.isDirectory())
     }
 
     @Test

--- a/Modder/modder/src/test/java/modder/TestPatcher.kt
+++ b/Modder/modder/src/test/java/modder/TestPatcher.kt
@@ -98,6 +98,15 @@ internal class TestPatcher {
     }
 
     @Test
+    fun GetSmaliClassesCount() {
+
+        val patcher = Patcher(testApkPathStr, decodeResource = false)
+        Assertions.assertEquals(4, patcher.GetSmaliClassesCount())
+
+    }
+
+
+    @Test
     @Throws(IOException::class)
     fun CreateNativeLibDir() {
         val patcher = Patcher(testApkPathStr, decodeResource = false)


### PR DESCRIPTION
functions at one dex/smali can't be more than 65,536

https://developer.android.com/build/multidex#:~:text=About%20the%2064K%20reference%20limit,-Android%20app%20(APK&text=The%20Dalvik%20Executable%20specification%20limits,methods%20in%20your%20own%20code.