### PR TITLE
Fix Crashes on some samsung device

### DIFF
--- a/ATG/app/src/main/java/com/kuhakupixel/atg/backend/Cpu.kt
+++ b/ATG/app/src/main/java/com/kuhakupixel/atg/backend/Cpu.kt
@@ -11,6 +11,7 @@ object Cpu {
             put("i686", Arch.x86)
             put("x86_64", Arch.x86_64)
             put("aarch64", Arch.arm64)
+            put("armv8l", Arch.arm32)
         }
     }
 

--- a/Modder/injector/gen_smali.py
+++ b/Modder/injector/gen_smali.py
@@ -27,6 +27,9 @@ import tempfile
 
 # ============================= paths ==================
 APK_SOURCE_ROOT_DIR = "./apk_source/hello-libs"
+APK_BUILT_OUTPUT_PATH = (
+    "apk_source/hello-libs/app/build/outputs/apk/debug/app-debug.apk"
+)
 
 OUT_CODE_FOR_INJECT_DIR = (
     "../../Modder/modder/src/main/resources/AceAndroidLib/code_to_inject"
@@ -34,10 +37,11 @@ OUT_CODE_FOR_INJECT_DIR = (
 SMALI_RELATIVE_DIR = "smali/com/AceInjector"
 
 OUT_SMALI_DIR = os.path.join(OUT_CODE_FOR_INJECT_DIR, SMALI_RELATIVE_DIR)
-OUT_SMALI_DIR_ZIPPED_FILE = OUT_SMALI_DIR 
+OUT_SMALI_DIR_ZIPPED_FILE = OUT_SMALI_DIR
 NATIVE_LIB_OUT_DIR = os.path.join(OUT_CODE_FOR_INJECT_DIR, "lib")
 
 # =========================== funcs =============
+
 
 def cp_folder(src: str, dest: str):
     # if destination exist remove
@@ -45,6 +49,7 @@ def cp_folder(src: str, dest: str):
         shutil.rmtree(dest)
     # then copy
     shutil.copytree(src, dest)
+
 
 # creating temp dir for decompilation result
 # https://stackoverflow.com/a/55104228/14073678
@@ -54,23 +59,17 @@ with tempfile.TemporaryDirectory() as temp_decompiled_apk_dir:
     generated_native_lib_dir = os.path.join(temp_decompiled_apk_dir, "lib")
 
     print("Generating temporary apk")
-    subprocess.run(["gradle", "assembleDebug"], cwd=APK_SOURCE_ROOT_DIR, shell=True)
+    subprocess.run("gradle assembleDebug", cwd=APK_SOURCE_ROOT_DIR, shell=True)
 
     # decode without resources and
     # put the smali results in smali folder
     # also force them using -f
     print("decompiling temp APK")
+    # command must be put in one string when setting `shell=True`
+    # https://stackoverflow.com/questions/26417658/subprocess-call-arguments-ignored-when-using-shell-true-w-list
     subprocess.run(
-        [
-            "apktool",
-            "d",
-            "apk_source/hello-libs/app/build/outputs/apk/debug/app-debug.apk",
-            "-r",
-            "-f",
-            "-o",
-            "%s" % (temp_decompiled_apk_dir),
-        ],
-        shell=True
+        f"apktool d {APK_BUILT_OUTPUT_PATH} -r -f -o {temp_decompiled_apk_dir}",
+        shell=True,
     )
 
     # put the smali for injection
@@ -80,12 +79,9 @@ with tempfile.TemporaryDirectory() as temp_decompiled_apk_dir:
     print("Copying native libs")
     cp_folder(generated_native_lib_dir, NATIVE_LIB_OUT_DIR)
 
-
     # zip the smali code for easier resource access by [Modder]
-    # don't need to add ".zip" extension, because 
+    # don't need to add ".zip" extension, because
     # it will do it for us
-    shutil.make_archive(
-        OUT_SMALI_DIR_ZIPPED_FILE, "zip", generated_smali_dir
-    )
+    shutil.make_archive(OUT_SMALI_DIR_ZIPPED_FILE, "zip", generated_smali_dir)
     print("Generated zipped smali at %s" % (OUT_SMALI_DIR_ZIPPED_FILE))
     print("Code for injection is generated at %s" % (OUT_CODE_FOR_INJECT_DIR))

--- a/Modder/modder/src/main/java/modder/ApkToolWrap.kt
+++ b/Modder/modder/src/main/java/modder/ApkToolWrap.kt
@@ -13,7 +13,9 @@ class ApkToolWrap {
         }
 
         fun Recompile(decompiledFolderStr: String, apkOutFileStr: String) {
-            val cmd = arrayOf("b", decompiledFolderStr, "--output", apkOutFileStr)
+
+	    // https://github.com/iBotPeaches/Apktool/issues/1978
+            val cmd = arrayOf("b", decompiledFolderStr, "--output", apkOutFileStr, "--use-aapt2")
 
             brut.apktool.Main.main(cmd)
         }


### PR DESCRIPTION
Problem:
	when the apk send `pid` command to `ACE`

	because on each command sent by apk, `ACE` will check process `pid` is alive

	the old way to check pid is alive is by listing `/proc/` directory
	on some device like samsung J7 it seems to crash with permission denied when I try to list /proc/<pid>/ other than my own process
	also reported,

Solution:
	use `kill` function from `<signal.h>` which doesn't require
	to list `/proc/` directory

	https://stackoverflow.com/questions/9152979/check-if-process-exists-given-its-pid